### PR TITLE
Add Vagrant and Provisioning Scripts

### DIFF
--- a/TDA4VMXEVM/Vagrantfile
+++ b/TDA4VMXEVM/Vagrantfile
@@ -1,0 +1,58 @@
+Vagrant.configure("2") do |config|
+  config.vm.box = "bento/ubuntu-16.04"
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  # config.vm.network "forwarded_port", guest: 69, host: 69
+  # config.vm.network "forwarded_port", guest: 111, host: 111
+  # config.vm.network "forwarded_port", guest: 2049, host: 2049
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  # config.vm.synced_folder "../data", "/vagrant_data"
+
+  config.vm.provider "virtualbox" do |vb|
+   #   vb.gui = true
+ 
+   #vb.memory = "4096"
+   # vb.cpus = 4
+
+ ### pass through Jacinto Console device on USB
+      #
+      # FIRST -- get the device with this command:
+      # `VBoxManage list usbhost`
+      #
+      # output looks something like this:
+      #
+      # Host USB Devices:
+      #
+      # UUID:               a96f03db-8dd9-432c-a87b-9afb763d3fc4
+      # VendorId:           0x0403 (0403)
+      # ProductId:          0x6011 (6011)
+      # Revision:           8.0 (0800)
+      # Port:               2
+      # USB version/speed:  0/High
+      # Manufacturer:       FTDI
+      # Product:            USB <-> Serial Converter
+      # SerialNumber:       49197900770A
+      # Address:            p=0x6011;v=0x0403;s=0x00000257a9d698e8;l=0x14420000
+      # Current State:      Busy
+
+    vb.customize ["modifyvm", :id, "--usb", "on"]
+    vb.customize ["modifyvm", :id, "--usbehci", "on"]
+
+      vb.customize ["usbfilter", "add", "0",
+       "--target", :id,
+         "--name", "JacintoJ7",
+         "--vendorid", "0403",
+         "--productid", "6011"
+         ]
+
+  end
+
+  config.vm.provision :shell, :path => "bootstrap.sh", :privileged => false, :env => {"USER_NAME" => 'vagrant'}
+  
+end

--- a/TDA4VMXEVM/aws_iot_greengrass/README.md
+++ b/TDA4VMXEVM/aws_iot_greengrass/README.md
@@ -17,6 +17,74 @@ tutorial expects you are working on a local workstation.
 You will need to complete all preparation steps to complete all the
 sections in this tutorial successfully.
 
+### Provisioning script (optional)
+
+For convenience, a Vagrantfile, provisioning script (`bootstrap.sh`) and build script (`starsdkbuild.sh`) are available to create a virtual machine under [Vagrant](https://vagrantup.com).
+
+#### Vagrant setup of SDK (optional)
+
+1. Download and install a Virtual Machine technology (such as [Virtual Box](https://www.virtualbox.org/)).
+
+*NB* - the Vagranfile here has been developed and tested with Virtual Box.
+
+2. Download and install [Vagrant](https://vagrantup.com).
+
+3. From the `TDA4VMXEVM` directory, start Vagrant with
+
+   ```bash
+   vagrant up
+   ```
+
+Vagrant will download an Ubuntu 16.04 virtual machine and run the provisioning script `bootstrap.sh` to 
+
+* Download cross-compiling toolchains
+* Clone the TI SDK from the git repo
+* Setup the SDK for development with meta-aws
+* Clone the meta-aws layer into the SDK tree
+
+This will take some time, but once the command is finished, connect to the virtual machine with
+
+   ```bash
+   vagrant ssh
+   ```
+
+4. The build can be initiated with
+
+   ```bash
+   cd /vagrant
+   ./startsdkbuild.sh
+   ```
+
+   *By default, the current host directory is shared on the guest as `/vagrant`.*
+
+### Setup with script (optional)
+
+If you choose *NOT* to use Vagrant (for example a Cloud9/EC2 instance, stand alone box, or other configuration), the `bootstrap.sh` script can be used to set up the SDK to be ready to build.
+
+1. Run the provisioning script
+
+   ```bash
+   bootstrap.sh
+   ```
+
+2. As with Vagrant, the provisioning script will 
+
+* Download cross-compiling toolchains
+* Clone the TI SDK from the git repo
+* Setup the SDK for development with meta-aws
+* Clone the meta-aws layer into the SDK tree
+
+3. The build can be initiated with
+
+   ```bash
+   startsdkbuild.sh
+   ```
+
+*The configuration of the virtual machine can be configured to limit processor and/or memory utilization, forward ports, share directories, etc by modifying `Vagrantfile`*
+
+### Manual setup and configuration
+
+
 1. [Download and install the TI Processor SDK for Linux
    (Automotive)](http://www.ti.com/tool/PROCESSOR-SDK-DRA8X-TDA4X).
    **Note** we will be using the flash utilities and boot files but
@@ -90,13 +158,14 @@ with some minor modifications to include IoT Greengrass.
    git clone -b zeus https://github.com/aws/meta-aws
    
    ```
+
 5. Add the `meta-aws` and `meta-java` layers to the build.
 
    ```text
-/src/tisdk/build/conf$ diff bblayers.conf.1 bblayers.conf
-30a31,32
-> 	/src/tisdk/sources/meta-aws \
+   /src/tisdk/build/conf$ diff bblayers.conf.1 bblayers.conf 30a31,32
+ 	> /src/tisdk/sources/meta-aws \
    ```
+
 6. Ensure the toolchain is configured in your terminal's environment.
 
    ```bash
@@ -138,7 +207,7 @@ with some minor modifications to include IoT Greengrass.
     boot files:
 
     ```bash
-/home/rpcme/ti-processor-sdk-linux-automotive-j7-evm-06_02_00/board-support/prebuilt-images/boot-j7-evm.tar.gz
+   /home/rpcme/ti-processor-sdk-linux-automotive-j7-evm-06_02_00/board-support/prebuilt-images/boot-j7-evm.tar.gz
     ```
 
     And the fully qualified path for the rootfs (your time and date will vary ):
@@ -259,6 +328,23 @@ rm -rf $BASEDIR/gcc-arm-8.3-2019.03-x86_64-arm-linux-gnueabihf
 rm -rf $BASEDIR/gcc-arm-8.3-2019.03-x86_64-aarch64-linux-gnu
 rm -rf $BASEDIR/tisdk
 ```
+
+### Vagrant cleanup (optional)
+
+To stop the vagrant virtual machine, log out of the vagrant ssh shell if already logged in, then
+   ```bash
+   vagrant halt
+   ```
+This will stop the vagrnat virtual machine, which can be restarted at any time with `vagrant up`.
+
+*NB* - the provisioning script (`boothstrap.sh`) is only run on the first creation of the virtual machine, subsequent calls to start the VM, will not re-provision.
+
+To remove the Vagrant virtual machine completely
+   ```bash
+   vagrant destroy
+   ```
+
+
 
 # Notes
 

--- a/TDA4VMXEVM/bootstrap.sh
+++ b/TDA4VMXEVM/bootstrap.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+# Install system requirements
+# target :  base Ubuntu 16.04 - Xenial
+
+sudo apt-get update
+sudo apt-get install -y git vim htop tree
+
+# Ubunut 16.04 doesn't activate ssh by default... so install it
+sudo apt-get install openssh-server -y
+
+sudo apt-get install picocom -y
+
+#
+# TI Arago SDK install
+#
+#
+# following https://github.com/aws-samples/meta-aws-demos/blob/master/TDA4VMXEVM/aws_iot_greengrass/README.md
+#
+# and bits from http://arago-project.org/wiki/index.php/Setting_Up_Build_Environment
+# 
+
+sudo apt-get install -y chrpath diffstat g++ 
+sudo apt-get install -y texinfo
+
+# sudo dpkg-reconfigure dash
+echo "dash dash/sh boolean false" | sudo debconf-set-selections
+sudo DEBIAN_FRONTEND=noninteractive dpkg-reconfigure dash
+
+cd ~
+export BASEDIR=$HOME
+mkdir -p ~/toolchains 
+
+wget https://developer.arm.com/-/media/Files/downloads/gnu-a/9.2-2019.12/binrel/gcc-arm-9.2-2019.12-x86_64-arm-none-linux-gnueabihf.tar.xz
+tar xvf gcc-arm-9.2-2019.12-x86_64-arm-none-linux-gnueabihf.tar.xz -C $HOME/toolchains
+
+wget https://developer.arm.com/-/media/Files/downloads/gnu-a/9.2-2019.12/binrel/gcc-arm-9.2-2019.12-x86_64-aarch64-none-linux-gnu.tar.xz
+tar xvf gcc-arm-9.2-2019.12-x86_64-aarch64-none-linux-gnu.tar.xz -C $HOME/toolchains
+
+cd $BASEDIR
+git clone git://arago-project.org/git/projects/oe-layersetup.git tisdk
+
+cd $BASEDIR/tisdk
+./oe-layertool-setup.sh -f configs/arago-zeus-config.txt
+
+cd build
+source conf/setenv
+
+cd $BASEDIR/tisdk/sources
+git clone -b zeus https://github.com/aws/meta-aws
+
+wget https://raw.githubusercontent.com/aws-samples/meta-aws-demos/master/TDA4VMXEVM/aws_iot_greengrass/j7-evm_iot_greengrass.conf
+mv j7-evm_iot_greengrass.conf $BASEDIR/tisdk/build/conf/j7-evm_iot_greengrass.conf
+
+export TOOLCHAIN_BASE=$BASEDIR/toolchains
+export TOOLCHAIN_PATH_ARMV7=$BASEDIR/toolchains/gcc-arm-9.2-2019.12-x86_64-arm-none-linux-gnueabihf
+export TOOLCHAIN_PATH_ARMV8=$BASEDIR/toolchains/gcc-arm-9.2-2019.12-x86_64-aarch64-none-linux-gnu

--- a/TDA4VMXEVM/startsdkbuild.sh
+++ b/TDA4VMXEVM/startsdkbuild.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# following https://github.com/aws-samples/meta-aws-demos/blob/master/TDA4VMXEVM/aws_iot_greengrass/README.md
+#
+# and bits from http://arago-project.org/wiki/index.php/Setting_Up_Build_Environment
+# 
+
+export BASEDIR=$HOME
+
+cd $BASEDIR/tisdk
+./oe-layertool-setup.sh -f configs/arago-zeus-config.txt
+
+cd $BASEDIR/tisdk/build
+source conf/setenv
+
+# patch bblayers.conf
+sed '/^\"/i    \\t\/home/'$USER'/tisdk/sources/meta-aws \\' conf/bblayers.conf >conf/bblayers.1.conf
+mv conf/bblayers.1.conf conf/bblayers.conf
+ 
+ # assume toolchains are installed
+export TOOLCHAIN_BASE=$BASEDIR/toolchains
+
+export TOOLCHAIN_PATH_ARMV7=$BASEDIR/toolchains/gcc-arm-9.2-2019.12-x86_64-arm-none-linux-gnueabihf
+export TOOLCHAIN_PATH_ARMV8=$BASEDIR/toolchains/gcc-arm-9.2-2019.12-x86_64-aarch64-none-linux-gnu
+
+# and go...
+cd $BASEDIR/tisdk/build
+source conf/setenv
+TOOLCHAIN_BASE=$BASEDIR/toolchains bitbake -r conf/j7-evm_iot_greengrass.conf arago-base-tisdk-image


### PR DESCRIPTION
Description of changes:
- created Vagrantfile and provisioning scripts for VM based development.
- bootstrap.sh is portable to fully replicate the SDK setup
- created a startsdkbuild script to properly setup paths and munge layers
- Updated README for above


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
