### PR TITLE
Add RPI4 64-bit. Change RPI32 to use dunfell.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ The number of demonstrations will increase over time and your contribution is ve
 | Hardware Partner | Hardware | Demonstration |
 |---|---|---|
 |[Intel Corporation](https://www.intel.com/)|[UP Squared Developer Kit](https://up-board.org/upsquared/development-kits/)|[AWS IoT Greengrass](up_squared/greengrass/README.md)|
-|Raspberry Pi|Raspberry Pi 4|[AWS IoT Greengrass](raspberry_pi4/aws_iot_greengrass/README.md)|
+|Raspberry Pi|Raspberry Pi 4 32-bit|[AWS IoT Greengrass](raspberry_pi4/aws_iot_greengrass/README.md)|
+|Raspberry Pi|Raspberry Pi 4 64-bit|[AWS IoT Greengrass](raspberry_pi4/aws_iot_greengrass_64/README.md)|
 |[Texas Instruments](https://www.ti.com/)|[AM572x Industrial Development Kit](http://www.ti.com/tool/TMDSIDK572)|[AWS IoT Greengrass](am572x_idk/aws_iot_greengrass/README.md)|
 |[Texas Instruments](https://www.ti.com/)|[AM574x Industrial Development Kit](http://www.ti.com/tool/TMDSIDK574)|[AWS IoT Greengrass](am574x_idk/aws_iot_greengrass/README.md)|
 |[Texas Instruments](https://www.ti.com/)|[Jacinto7 TDA4VMXEVM](http://www.ti.com/tool/TDA4VMXEVM)|[AWS IoT Greengrass](TDA4VMXEVM/aws_iot_greengrass/README.md)|

--- a/adlink-lec-px30/aws_iot_greengrass/README.md
+++ b/adlink-lec-px30/aws_iot_greengrass/README.md
@@ -1,0 +1,218 @@
+# AWS IoT Greengrass for the ADLink LEC-PX30
+
+This tutorial was prepared for customers running Robomaker on their
+ADLink LEC-PX30 device.
+
+This tutorial was performed on an Amazon EC2 instance with instance
+type c5.18xlarge.
+
+In this tutorial, we use the meta-aws branch **zeus** since the ADLINK
+repository instruction specifies **zeus**.
+
+You may perform the build steps on an EC2 instance, copy the image
+locally, and then flash the MicroSD locally.  The steps in this
+tutorial expects you are working on a local workstation.
+
+## Preparation
+
+You will need to complete all preparation steps to complete all the
+sections in this tutorial successfully.
+
+1. Perform all workstation preparation steps as defined in the Yocto
+   Mega Manual.
+2. An [AWS Account](https://aws.amazon.com/free) and an [AWS Identity
+   and Access Management (IAM)](https://aws.amazon.com/iam/) with
+   authorization to run the [IoT Greengrass
+   Tutorial](https://docs.aws.amazon.com/greengrass/latest/developerguide/gg-gs.html)
+   in the context of your logged in [IAM
+   User](https://docs.aws.amazon.com/IAM/latest/UserGuide/introduction_identity-management.html).
+
+## Build and flash the image
+
+1. Begin by following the instruction on ADLINK's github page for [LEC PX30 with IPi SMARC](https://github.com/ADLINK/meta-adlink-rockchip/wiki/01.-Build-Yocto-Image-on-LEC-PX30-with-IPi-SMARC).
+
+   We used commands in `bash` shell, in this order, after updating OS packages:
+
+   a. Define the `BSP_FOLDER` variable which is the working base directory.
+
+      ```bash
+BSP_FOLDER=~/lec-px30
+mkdir ${BSP_FOLDER} && cd ${BSP_FOLDER}
+      ```
+
+b. Create a helper function for performing `git` operations:
+
+      ```bash
+function clone() {
+    git clone $(eval echo \${${1}_URL}) -b $(eval echo \${${1}_B})
+    cd $(eval echo \${${1}_D})
+    git checkout $(eval echo \${${1}_CH})
+    cd ..
+}
+      ```
+
+   c. Define the variables we will use for the build environment
+      configuration.
+ 
+      ```bash
+BRANCH=zeus
+
+POKY_URL=git://git.yoctoproject.org/poky.git
+POKY_D=poky
+POKY_B=${BRANCH}
+POKY_CH=f9ef210967ab34168d4a24930987dc0731baf56f
+
+META_OPENEMBEDDED_URL=git://git.openembedded.org/meta-openembedded.git
+META_OPENEMBEDDED_D=meta-openembedded
+META_OPENEMBEDDED_B=${BRANCH}
+META_OPENEMBEDDED_CH=bb65c27a772723dfe2c15b5e1b27bcc1a1ed884c
+
+META_ROCKCHIP_URL=https://github.com/ADLINK-EPM/meta-rockchip.git
+META_ROCKCHIP_D=meta-rockchip
+META_ROCKCHIP_B=${BRANCH}
+META_ROCKCHIP_CH=8f7727fb24e40ad193373f2ec57a2612799a834b
+
+META_ADLINK_ROCKCHIP_URL=https://github.com/adlink/meta-adlink-rockchip.git
+META_ADLINK_ROCKCHIP_D=meta-adlink-rockchip
+META_ADLINK_ROCKCHIP_B=${BRANCH}
+META_ADLINK_ROCKCHIP_CH=441b5f001a7d1716282e80d8f64309708e51f02a
+
+META_ADLINK_SEMA_URL=https://github.com/adlink/meta-adlink-sema.git
+META_ADLINK_SEMA_D=meta-adlink-sema
+META_ADLINK_SEMA_B=sema4.0
+META_ADLINK_SEMA_CH=2151d926328742ff577afd055f15be0a6397a644
+
+META_BROWSER_URL=https://github.com/OSSystems/meta-browser.git
+META_BROWSER_D=meta-browser
+META_BROWSER_B=${BRANCH}
+META_BROWSER_CH=830ef438e81ba5fc915b1855e69f02b2c286b21a
+
+META_CLANG_URL=git://github.com/kraj/meta-clang
+META_CLANG_D=meta-clang
+META_CLANG_B=${BRANCH}
+META_CLANG_CH=81ba160c95b12b2922f99b60bef25ab37a5e2f0e
+
+META_RUST_URL=git://github.com/meta-rust/meta-rust
+META_RUST_D=meta-rust
+META_RUST_B=master
+META_RUST_CH=a012a1027defe28495f06ed522a7a82bdd59a610
+
+META_AWS_URL=git://github.com/aws/meta-aws
+META_AWS_D=meta-aws
+META_AWS_B=$BRANCH
+META_AWS_CH=b5a1707cd23d462e963958fcfda59b56a08e6710
+      ```
+   5. Clone repositories
+
+      ```bash
+clone POKY
+clone META_OPENEMBEDDED
+clone META_ROCKCHIP
+clone META_ADLINK_ROCKCHIP
+clone META_ADLINK_SEMA
+clone META_BROWSER
+clone META_CLANG
+clone META_RUST
+clone META_AWS
+      ```
+   6. Initialize environment.
+      ```bash
+TEMPLATECONF=$PWD/meta-adlink-rockchip/conf/adlink-conf/
+source poky/oe-init-build-env
+cd ${BSP_FOLDER}
+cp meta-adlink-rockchip/conf/adlink-conf/mirror.conf.sample \
+   build/conf/mirror.conf
+      ```
+   7. Perform baseline build
+      ```
+bitbake core-image-mb -r build/conf/mirror.conf
+      ```
+
+2. After the baseline has been built, we will continue on to configure
+   the build system for AWS IoT Greengrass.
+
+
+   
+   ```text
+# POKY_BBLAYERS_CONF_VERSION is increased each time build/conf/bblayers.conf
+# changes incompatibly
+POKY_BBLAYERS_CONF_VERSION = "2"
+
+BBPATH = "${TOPDIR}"
+BBFILES ?= ""
+
+BBLAYERS ?= " \
+  /src/poky-lec-px30/meta \
+  /src/poky-lec-px30/meta-poky \
+  /src/poky-lec-px30/meta-rockchip \
+  /src/poky-lec-px30/meta-adlink-rockchip \
+  /src/poky-lec-px30/meta-openembedded/meta-networking \
+  /src/poky-lec-px30/meta-openembedded/meta-python \
+  /src/poky-lec-px30/meta-openembedded/meta-oe \
+  /src/poky-lec-px30/meta-openembedded/meta-filesystems \
+  /src/poky-lec-px30/meta-java \
+  /src/poky-lec-px30/meta-virtualization \
+  /src/poky-lec-px30//meta-browser \
+  /src/poky-lec-px30//meta-clang \
+  /src/poky-lec-px30//meta-rust \
+  /src/poky-lec-px30/meta-aws \
+  "
+   ```
+
+7. Build the image.
+
+   ```bash
+   TEMPLATECONF=$BASEDIR/$DIST/meta-adlink-rockchip/conf/adlink-conf/
+   bitbake -r conf/iot_greengrass_idt_full.conf core-image-mini
+   ```
+
+   After building, the images will be in the following directory.
+
+   ```bash
+   ls tmp/deploy/images/raspberrypi4/*sdimg
+   ```
+
+    Where my image happens to be:
+
+    ```bash
+    FILE=tmp/deploy/images/raspberrypi4/core-image-minimal-raspberrypi4-20200709170237.rootfs.rpi-sdimg
+    ```
+
+8. Image the target device using `dd`.  You can also use an imaging
+   tool you are comfortable with. **BE SUPER CAREFUL**
+   
+   ```bash
+   sudo dd if=$FILE of=`/dev/sda bs=1m
+   ```
+
+8. Modify config.txt
+
+   In my case, I use the UART to communicate with the Raspberry Pi.  I
+   then remove the remark for the `init_uart_baud` and
+   `init_uart_clock` properties.
+   
+
+9. Eject the SD Card, insert the SD Card to the Raspberry Pi, connect
+the UART and Ethernet, and power up.
+
+
+## Go build solutions
+
+Your image with IoT Greengrass is now up and running.  What's next?
+
+When you go through the [IoT Greengrass
+Tutorial](https://docs.aws.amazon.com/greengrass/latest/developerguide/gg-gs.html),
+Do not run the Quick Start or Module 1.  You will need to follow the
+[Configure AWS IoT Greengrass on AWS
+IoT](https://docs.aws.amazon.com/greengrass/latest/developerguide/gg-config.html)
+chapter to initialize your account for IoT Greengrass, create your
+Greengrass Group, and then apply the `config.json` and credentials to
+the target device.
+
+
+## References
+
+https://github.com/ADLINK/meta-adlink-rockchip/tree/zeus
+
+
+© 2020, Amazon Web Services, Inc. or its affiliates. All rights reserved.

--- a/raspberry_pi4/aws_iot_greengrass/README.md
+++ b/raspberry_pi4/aws_iot_greengrass/README.md
@@ -4,10 +4,6 @@ You may perform the build steps on an EC2 instance, copy the image
 locally, and then flash the MicroSD locally.  The steps in this
 tutorial expects you are working on a local workstation.
 
-Note that even though **dunfell** has released at the time of posting,
-AWS IoT Greengrass depends on Python 3.7 so we are using the **zeus**
-branch.
-
 ## Preparation
 
 You will need to complete all preparation steps to complete all the
@@ -24,6 +20,26 @@ sections in this tutorial successfully.
 
 ## Build and flash the image
 
+The build was performed under the following configuration.  If your
+build breaks when working against the tip of the branch, consider
+checking out these commit hashes for the respective layers.
+
+```
+meta                 
+meta-poky            
+meta-yocto-bsp       = "dunfell:40e448301edf142dc00a0ae6190017adac1e57b2"
+meta-networking      
+meta-python          
+meta-oe              
+meta-filesystems     = "dunfell:2a5c534d2b9f01e9c0f39701fccd7fc874945b1c"
+meta-raspberrypi     = "dunfell:806575fc1d1ea3a6852210b83be9f2999d93b0da"
+meta-java            = "dunfell:03537feee539526ec9bb0cf4f55dd4eef6badc71"
+meta-virtualization  = "dunfell:ff997b6b3ba800978546098ab3cdaa113b6695e1"
+meta-aws             = "dunfell:758f2f34ef1461efba0b8bb4a5756a67fbd4e4ce"
+```
+
+
+
 1. Open a terminal window on your workstation.
 
    **NOTE** For the sake of this tutorial, the variable `BASE` refers to the
@@ -34,7 +50,7 @@ sections in this tutorial successfully.
    ```bash
    export BASEDIR=$HOME
    export DIST=poky-rpi4
-   export B=zeus
+   export B=dunfell
    ```
 
    Clone the Poky base layer to include OpenEmbedded Core, Bitbake,

--- a/raspberry_pi4/aws_iot_greengrass_64/README.md
+++ b/raspberry_pi4/aws_iot_greengrass_64/README.md
@@ -1,0 +1,184 @@
+# AWS IoT Greengrass for the Raspberry Pi 4
+
+You may perform the build steps on an EC2 instance, copy the image
+locally, and then flash the MicroSD locally.  The steps in this
+tutorial expects you are working on a local workstation.
+
+**NOTE** OpenJDK-8 would not cleanly build so it has been removed from
+the configuration.  However, it has been left in the steps and we will
+check its build-ability at some interval.  Please also file an issue
+if you notice that it does in fact build cleanly for a specific commit
+hash on the target branch.
+
+## Preparation
+
+You will need to complete all preparation steps to complete all the
+sections in this tutorial successfully.
+
+1. Perform all workstation preparation steps as defined in the Yocto
+   Mega Manual.
+2. An [AWS Account](https://aws.amazon.com/free) and an [AWS Identity
+   and Access Management (IAM)](https://aws.amazon.com/iam/) with
+   authorization to run the [IoT Greengrass
+   Tutorial](https://docs.aws.amazon.com/greengrass/latest/developerguide/gg-gs.html)
+   in the context of your logged in [IAM
+   User](https://docs.aws.amazon.com/IAM/latest/UserGuide/introduction_identity-management.html).
+
+## Build and flash the image
+
+The build was performed under the following configuration.  If your
+build breaks when working against the tip of the branch, consider
+checking out these commit hashes for the respective layers.
+
+```
+meta                 
+meta-poky            
+meta-yocto-bsp       = "dunfell:40e448301edf142dc00a0ae6190017adac1e57b2"
+meta-networking      
+meta-python          
+meta-oe              
+meta-filesystems     = "dunfell:2a5c534d2b9f01e9c0f39701fccd7fc874945b1c"
+meta-raspberrypi     = "dunfell:806575fc1d1ea3a6852210b83be9f2999d93b0da"
+meta-java            = "dunfell:03537feee539526ec9bb0cf4f55dd4eef6badc71"
+meta-virtualization  = "dunfell:ff997b6b3ba800978546098ab3cdaa113b6695e1"
+meta-aws             = "dunfell:758f2f34ef1461efba0b8bb4a5756a67fbd4e4ce"
+```
+
+1. Open a terminal window on your workstation.
+
+   **NOTE** For the sake of this tutorial, the variable `BASE` refers to the
+   build environment parent directory.  For many people, this will be
+   `$HOME`.  If you are using another partition as the base directory,
+   please set it accordingly.
+
+   ```bash
+   export BASEDIR=$HOME
+   export DIST=poky-rpi4
+   export B=dunfell
+   ```
+
+   Clone the Poky base layer to include OpenEmbedded Core, Bitbake,
+   and so forth to seed the Yocto build environment.
+
+   ```bash
+   git clone -b $B git://git.yoctoproject.org/poky.git $BASEDIR/$DIST
+   ```
+
+3. Clone additional dependent repositories.  Note that we are cloning
+   only what is required for IoT Greengrass.
+
+   ```bash
+   git clone -b $B git://git.openembedded.org/meta-openembedded \
+       $BASEDIR/$DIST/meta-openembedded
+   git clone -b $B git://git.yoctoproject.org/meta-raspberrypi \
+       $BASEDIR/$DIST/meta-raspberrypi
+   git clone -b $B git://git.yoctoproject.org/meta-virtualization \
+       $BASEDIR/$DIST/meta-virtualization
+   git clone -b $B git://git.yoctoproject.org/meta-java \
+       $BASEDIR/$DIST/meta-java
+   git clone -b $B git://github.com/aws/meta-aws \
+       $BASEDIR/$DIST/meta-aws
+   ```
+
+4. Source the Yocto environment script.  This seeds the `build/conf`
+   directory.
+
+   ```bash
+   cd $BASEDIR/$DIST
+   . ./oe-init-build-env
+   ```
+
+5. Copy the `local.conf` we will use for this demonstration to your
+   `conf` directory.
+
+   ```bash
+   wget https://raw.githubusercontent.com/aws-samples/meta-aws-demos/master/raspberry_pi4/aws_iot_greengrass_64/rpi4_iot_greengrass_idt.conf
+   mv rpi4_iot_greengrass_idt.conf \
+      $BASEDIR/$DIST/build/conf/rpi4_iot_greengrass_idt.conf
+   ```
+
+6. Modify `conf/bblayers.conf` to include required layers. After
+   editing, your conf file should look like the following. Note that
+   some success may be achieved by using `bitbake-layer add-layer` but
+   many times after adding the java and virtualization layers this
+   utility breaks.  On the author's system, `BASEDIR` is `/src`.
+   
+   ```text
+   # POKY_BBLAYERS_CONF_VERSION is increased each time build/conf/bblayers.conf
+   # changes incompatibly
+   POKY_BBLAYERS_CONF_VERSION = "2"
+
+   BBPATH = "${TOPDIR}"
+   BBFILES ?= ""
+
+   BBLAYERS ?= " \
+     /src/poky-rpi4/meta \
+     /src/poky-rpi4/meta-poky \
+     /src/poky-rpi4/meta-openembedded/meta-networking \
+     /src/poky-rpi4/meta-openembedded/meta-python \
+     /src/poky-rpi4/meta-openembedded/meta-oe \
+     /src/poky-rpi4/meta-openembedded/meta-filesystems \
+     /src/poky-rpi4/meta-raspberrypi \
+     /src/poky-rpi4/meta-virtualization \
+     /src/poky-rpi4/meta-aws \
+     "
+   ```
+
+7. Build the image.
+
+   ```bash
+   bitbake -r conf/rpi4_iot_greengrass_idt.conf core-image-minimal
+   ```
+
+   After building, the images will be in the following directory.
+
+   ```bash
+   ls tmp/deploy/images/raspberrypi4/*sdimg
+   ```
+
+    Where my image happens to be:
+
+    ```bash
+    FILE=tmp/deploy/images/raspberrypi4/core-image-minimal-raspberrypi4-20200709170237.rootfs.rpi-sdimg
+    ```
+
+8. Image the target device using `dd`.  You can also use an imaging
+   tool you are comfortable with. **BE SUPER CAREFUL**
+   
+   First identify the device using `lsblk` and then set it to the 
+   output variable. This will help you confirm that this is really 
+   the target device you want to image. **BE SUPER CAREFUL**
+   
+   ```bash
+   lsblk
+   #DEVICE=<IDENTIFIED DEVICE, i.e.>
+   DEVICE=/dev/sda
+   sudo dd if=$FILE of=$DEVICE bs=1m
+   ```
+
+9. Modify config.txt
+
+   In my case, I use the UART to communicate with the Raspberry Pi.  I
+   then remove the remark for the `init_uart_baud` and
+   `init_uart_clock` properties.
+   
+
+10. Eject the SD Card, insert the SD Card to the Raspberry Pi, connect
+the UART and Ethernet, and power up.
+
+
+## Go build solutions
+
+Your image with IoT Greengrass is now up and running.  What's next?
+
+When you go through the [IoT Greengrass
+Tutorial](https://docs.aws.amazon.com/greengrass/latest/developerguide/gg-gs.html),
+Do not run the Quick Start or Module 1.  You will need to follow the
+[Configure AWS IoT Greengrass on AWS
+IoT](https://docs.aws.amazon.com/greengrass/latest/developerguide/gg-config.html)
+chapter to initialize your account for IoT Greengrass, create your
+Greengrass Group, and then apply the `config.json` and credentials to
+the target device.
+
+
+© 2020, Amazon Web Services, Inc. or its affiliates. All rights reserved.

--- a/raspberry_pi4/aws_iot_greengrass_64/rpi4_iot_greengrass_idt.conf
+++ b/raspberry_pi4/aws_iot_greengrass_64/rpi4_iot_greengrass_idt.conf
@@ -1,0 +1,3 @@
+MACHINE = "raspberrypi4-64"
+IMAGE_INSTALL_append = " greengrass openssh ntp docker python3-docker-compose"
+IMAGE_FSTYPES = "rpi-sdimg"


### PR DESCRIPTION
*Issue #, if available:*
Fixes #3 

*Description of changes:*
Add walk-through for RPI4 64 bit
Change walk-through for RPI4 32 bit to use dunfell.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
