### PR TITLE
Add libtim-vx for i.MX8MPEVK

### DIFF
--- a/nxp/imx8m/README.md
+++ b/nxp/imx8m/README.md
@@ -118,6 +118,10 @@ IMAGE_INSTALL_append = " python3-grpcio"
 IMAGE_INSTALL_append = " python3-protobuf"
 IMAGE_INSTALL_append = " opencv"
 ```
+If you are building this image for the NXP i.MX 8M Plus EVK and want to perform machine learning inference on the Neural Processing Unit, you will need to add the following line to build libtim-vx:
+```
+IMAGE_INSTALL_append = " tim-vx"
+```
 
 local.conf should look similar to the following:
 ```


### PR DESCRIPTION
For users wanting to take advantage of libtim-vx / NPU acceleration on the i.MX 8M Plus, they will need to add an additional append in local.conf to build libtim-vx.so.

*Issue #, if available:*

*Description of changes:*
```
IMAGE_INSTALL_append = " tim-vx"
```
and explanation


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
