### PR TITLE
Update repo.xml

### DIFF
--- a/rpi_foundation/rpi4-64/aws-iot-greengrass-v2/dunfell/buildspec.yml
+++ b/rpi_foundation/rpi4-64/aws-iot-greengrass-v2/dunfell/buildspec.yml
@@ -22,7 +22,7 @@ phases:
       - mkdir $HOME/dist
       - cd $HOME/dist
       - $HOME/repo init -u
-        https://github.com/rdematos/meta-aws-demos
+        https://github.com/aws-samples/meta-aws-demos
           -b patch-1
           -m rpi_foundation/rpi4-64/aws-iot-greengrass-v2/dunfell/repo.xml
       - $HOME/repo sync

--- a/rpi_foundation/rpi4-64/aws-iot-greengrass-v2/dunfell/buildspec.yml
+++ b/rpi_foundation/rpi4-64/aws-iot-greengrass-v2/dunfell/buildspec.yml
@@ -22,7 +22,8 @@ phases:
       - mkdir $HOME/dist
       - cd $HOME/dist
       - $HOME/repo init -u
-        https://github.com/aws-samples/meta-aws-demos
+        https://github.com/rdematos/meta-aws-demos
+          -b patch-1
           -m rpi_foundation/rpi4-64/aws-iot-greengrass-v2/dunfell/repo.xml
       - $HOME/repo sync
       - export PATH=$HOME/dist/poky/scripts:$HOME/dist/poky/bitbake/bin:$PATH

--- a/rpi_foundation/rpi4-64/aws-iot-greengrass-v2/dunfell/repo.xml
+++ b/rpi_foundation/rpi4-64/aws-iot-greengrass-v2/dunfell/repo.xml
@@ -2,9 +2,9 @@
 <manifest>
   <default sync-j="4" />
   
-  <remote name="oe"  fetch="git://git.openembedded.org" />
-  <remote name="yp"  fetch="git://git.yoctoproject.org" />
-  <remote name="aws" fetch="git://github.com/aws" />
+  <remote name="oe"  fetch="https://git.openembedded.org" />
+  <remote name="yp"  fetch="https://git.yoctoproject.org" />
+  <remote name="aws" fetch="https://github.com/aws" />
 
   <project remote="oe"
 	   revision="dunfell"

--- a/rpi_foundation/rpi4-64/aws-iot-greengrass-v2/gatesgarth/repo.xml
+++ b/rpi_foundation/rpi4-64/aws-iot-greengrass-v2/gatesgarth/repo.xml
@@ -2,9 +2,9 @@
 <manifest>
   <default sync-j="4" />
   
-  <remote name="oe"  fetch="git://git.openembedded.org" />
-  <remote name="yp"  fetch="git://git.yoctoproject.org" />
-  <remote name="aws" fetch="git://github.com/aws" />
+  <remote name="oe"  fetch="https://git.openembedded.org" />
+  <remote name="yp"  fetch="https://git.yoctoproject.org" />
+  <remote name="aws" fetch="https://github.com/aws" />
 
   <project remote="oe"
 	   revision="gatesgarth"

--- a/rpi_foundation/rpi4-64/aws-iot-greengrass-v2/hardknott/buildspec.yml
+++ b/rpi_foundation/rpi4-64/aws-iot-greengrass-v2/hardknott/buildspec.yml
@@ -22,7 +22,7 @@ phases:
       - mkdir $HOME/dist
       - cd $HOME/dist
       - $HOME/repo init -u
-        https://github.com/rdematos/meta-aws-demos
+        https://github.com/aws-samples/meta-aws-demos
           -b patch-1
           -m rpi_foundation/rpi4-64/aws-iot-greengrass-v2/hardknott/repo.xml
       - $HOME/repo sync

--- a/rpi_foundation/rpi4-64/aws-iot-greengrass-v2/hardknott/buildspec.yml
+++ b/rpi_foundation/rpi4-64/aws-iot-greengrass-v2/hardknott/buildspec.yml
@@ -22,7 +22,8 @@ phases:
       - mkdir $HOME/dist
       - cd $HOME/dist
       - $HOME/repo init -u
-        https://github.com/aws-samples/meta-aws-demos
+        https://github.com/rdematos/meta-aws-demos
+          -b patch-1
           -m rpi_foundation/rpi4-64/aws-iot-greengrass-v2/hardknott/repo.xml
       - $HOME/repo sync
       - export PATH=$HOME/dist/poky/scripts:$HOME/dist/poky/bitbake/bin:$PATH

--- a/rpi_foundation/rpi4-64/aws-iot-greengrass-v2/hardknott/repo.xml
+++ b/rpi_foundation/rpi4-64/aws-iot-greengrass-v2/hardknott/repo.xml
@@ -2,9 +2,9 @@
 <manifest>
   <default sync-j="4" />
   
-  <remote name="oe"  fetch="git://git.openembedded.org" />
-  <remote name="yp"  fetch="git://git.yoctoproject.org" />
-  <remote name="aws" fetch="git://github.com/aws" />
+  <remote name="oe"  fetch="https://git.openembedded.org" />
+  <remote name="yp"  fetch="https://git.yoctoproject.org" />
+  <remote name="aws" fetch="https://github.com/aws" />
 
   <project remote="oe"
 	   revision="master"


### PR DESCRIPTION
mitigated issues that unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
